### PR TITLE
added 2nd address lines

### DIFF
--- a/partials/partial-checkout-address.htm
+++ b/partials/partial-checkout-address.htm
@@ -28,8 +28,13 @@
 		<span class="error"></span>
 	</div>
 	<div class="billing-address">
-		<label for="billing_address">Address *</label>
+		<label for="billing_address">Address line 1 *</label>
 		<textarea id="billing_address" name="billingInfo[streetAddressLine1]">{{ billingInfo.streetAddressLine1 }}</textarea>
+		<span class="error"></span>
+	</div>
+	<div class="billing-address">
+		<label for="billing_address">Address line 2</label>
+		<textarea id="billing_address" name="billingInfo[streetAddressLine2]">{{ billingInfo.streetAddressLine2 }}</textarea>
 		<span class="error"></span>
 	</div>
 	<div class="billing-city">
@@ -92,8 +97,13 @@
 		
 	</div>
 	<div class="shipping-address">
-		<label for="shipping_address">Address *</label>
+		<label for="shipping_address">Address line 1 *</label>
 		<textarea name="shippingInfo[streetAddressLine1]" id="shipping_address">{{ shippingInfo.streetAddressLine1 }}</textarea>
+		<span class="error"></span>
+	</div>
+	<div class="shipping-address">
+		<label for="shipping_address">Address line 2</label>
+		<textarea name="shippingInfo[streetAddressLine2]" id="shipping_address">{{ shippingInfo.streetAddressLine2 }}</textarea>
 		<span class="error"></span>
 	</div>
 	<div class="shipping-city">

--- a/partials/partial-customerprofile.htm
+++ b/partials/partial-customerprofile.htm
@@ -6,43 +6,49 @@
   <hr>
 
   <div class="billing-first-name">
-    <label for="first_name">First Name</label>
+    <label for="first_name">First Name *</label>
     <input name="billing[first_name]" id="first_name" type="text" class="text" value="{{ billing.first_name }}"/>
     <span class="error"></span>
   </div>
 
   <div class="billing-last-name">
-    <label for="last_name">Last Name</label>
+    <label for="last_name">Last Name *</label>
     <input name="billing[last_name]" id="last_name" type="text" class="text" value="{{ billing.last_name }}"/>
     <span class="error"></span>
   </div>
 
   <div class="billing-email">
-    <label for="email">E-mail Address</label>
+    <label for="email">E-mail Address *</label>
     <input type="text" name="billing[email]" id="email" value="{{ customer.email }}" />
     <span class="error"></span>
   </div>
 
   <div class="billing-address">
-    <label for="billing_address">Address</label>
+    <label for="billing_address">Address line 1 *</label>
     <textarea id="billing_address" name="billing[street_address]">{{ billing.street_address }}</textarea>
     <span class="error"></span>
   </div>
 
+  <div class="billing-address">
+    <label for="billing_address">Address line 2</label>
+    <textarea id="billing_address" name="billing[street_address_line2]">{{ billing.street_address_line2 }}</textarea>
+    <span class="error"></span>
+  </div>
+
   <div class="billing-city">
-    <label for="billing_city">City</label>
+    <label for="billing_city">City *</label>
     <input type="text" name="billing[city]" id="billing_city" value="{{ billing.city }}"/>
     <span class="error"></span>
   </div>
 
   <div class="billing-postal-code">
-    <label for="billing_zip">Zip Code</label>
+    <label for="billing_zip">Zip Code *</label>
     <input type="text" id="billing_zip" name="billing[postal_code]" value="{{ billing.postal_code }}"/>
     <span class="error"></span>
   </div>
 
   <div class="billing-country">
-    <label for="billing_country">Country</label>
+    <label for="billing_country">Country *</label>
     <!-- The state selector updates automatically when the country changes. See app.js for the implementation details. -->        
     <select id="billing_country" name="billing[shop_country_id]" data-state-selector="#billing_state" data-current-state="{{ billing.country.id }}">
       {% for country in countries %}
@@ -53,7 +59,7 @@
   </div>
 
   <div class="billing-state">
-    <label for="billing_state">State</label>
+    <label for="billing_state">State *</label>
     <select id="billing_state" name="billing[shop_state_id]" data-ajax-refresh > 
     {% set states = billingStates %}
     {% set selected = billing.state.id %}
@@ -83,13 +89,13 @@
   <input type="hidden" name="shipping[id]" value="{{ shipping.id }}" />
 
   <div class="shipping-first-name">
-    <label for="shipping_first_name">First Name</label>
+    <label for="shipping_first_name">First Name *</label>
     <input type="text" name="shipping[first_name]" id="shipping_first_name" value="{{ shipping.first_name }}"/>
     <span class="error"></span>
   </div>
 
   <div class="shipping-last-name">
-    <label for="shipping_last_name">Last Name</label>
+    <label for="shipping_last_name">Last Name *</label>
     <input type="text" name="shipping[last_name]" id="shipping_last_name" value="{{ shipping.last_name }}"/>
     <span class="error"></span>
   </div>
@@ -99,8 +105,14 @@
   </div>
 
   <div class="shipping-address">
-    <label for="shipping_address">Address</label>
+    <label for="shipping_address">Address line 1 *</label>
     <textarea name="shipping[street_address]" id="shipping_address">{{ shipping.street_address }}</textarea>
+    <span class="error"></span>
+  </div>
+
+  <div class="shipping-address">
+    <label for="shipping_address">Address line 2</label>
+    <textarea name="shipping[street_address_line2]" id="shipping_address">{{ shipping.street_address_line2 }}</textarea>
     <span class="error"></span>
   </div>
 


### PR DESCRIPTION
#3091
- [ ] address line 2 shows up in database after placing order as a guest (shop_customer_address table, street_address_line2 column)
- [ ] address line 2 shows in Orders in store backend
- [ ] address line 2 shows up for billing and shipping info in front end
- [ ] address line 2 field repopulates for logged in users and guest users (same session)
- [ ] address line 2 shows up in database when a new customer registers and their address line 2 is added from the `/profile` page
