### PR TITLE
Receipt Page - Order Items Not Rendering Correctly For Upcoming Orders

### DIFF
--- a/partials/cart-contents-items.htm
+++ b/partials/cart-contents-items.htm
@@ -24,7 +24,7 @@
   </div>
 </header>
 
-{% for item in (order ? order.orderItems : items) %}
+{% for item in items %}
     <section class="cell contents-product">
       <div class="grid-x grid-padding-x">
         <header class="cell large-8 clearfix">

--- a/partials/cart-contents.htm
+++ b/partials/cart-contents.htm
@@ -23,7 +23,7 @@
     {{ partial('cart-contents-items', { listTitle: 'Upcoming subscription items', items: upcomingItems, checkoutMode: checkoutMode }) }}
     {{ partial('cart-contents-items', { listTitle: 'Items shipping immediately', items: items, checkoutMode: checkoutMode }) }}
   {% else %}
-    {{ partial('cart-contents-items', { items: items }) }}
+    {{ partial('cart-contents-items', { items: (order ? order.orderItems : items)}) }}
   {% endif %}
 
   {% if items | length > 0 %}


### PR DESCRIPTION
### Changes

- Moves orderItems ternary into cart-contents partial from cart-contents-items.
  - Was preventing correct order items from rendering for upcoming

<img width="1230" alt="screen shot 2018-09-13 at 11 45 21 am" src="https://user-images.githubusercontent.com/3967712/45508772-8dd7e780-b74a-11e8-9d5c-e257452a371c.png">

## Test Checklist
- [ ] Verify order receipt pages rendering properly again.
- [ ] Regression test cart item/checkout lists.