### PR TITLE
Upcoming Order Updates - Follow-Up

### DIFF
--- a/partials/cart-contents.htm
+++ b/partials/cart-contents.htm
@@ -10,6 +10,8 @@
 {% if page.url == '/checkout' %}
   {% set checkoutMode = true %}
 {% endif %}
+{% set hasItems =  items | length > 0 %}
+{% set hasUpcomingItems =  upcomingItems | length > 0 %}
 
 {{ open_form({
      'class': 'grid-x grid-padding-x',
@@ -19,14 +21,15 @@
         : '.cart-page=cart-page,.cart-count=cart-count,.mini-cart=mini-cart'
    })
 }}
-  {% if upcomingItems | length > 0  %}
+  {% if hasUpcomingItems %}
     {{ partial('cart-contents-items', { listTitle: 'Upcoming subscription items', items: upcomingItems, checkoutMode: checkoutMode }) }}
-    {{ partial('cart-contents-items', { listTitle: 'Items shipping immediately', items: items, checkoutMode: checkoutMode }) }}
-  {% else %}
-    {{ partial('cart-contents-items', { items: (order ? order.orderItems : items)}) }}
   {% endif %}
 
-  {% if items | length > 0 %}
+  {% if hasItems  %}
+    {{ partial('cart-contents-items', { listTitle: 'Items shipping immediately', items: items, checkoutMode: checkoutMode }) }}
+  {% endif %}
+
+  {% if hasItems or hasUpcomingItems %}
   <hr/>
   <section class="cell cart-summary">
       <div class="grid-x grid-padding-x">
@@ -44,5 +47,4 @@
     </div>
   </section>
   {% endif %}
-
 {{ close_form() }}

--- a/partials/cart-page.htm
+++ b/partials/cart-page.htm
@@ -38,7 +38,7 @@
             <a class="button hollow" href="/products">Continue Shopping</a>
           </div>
           <div class="cell large-shrink footer-right">
-            {% if items | length > 0 %}
+            {% if items | length > 0 or upcomingItems | length > 0 %}
               <a class="button" href="/checkout">Checkout</a>
             {% endif %}
           </div>

--- a/partials/cart-page.htm
+++ b/partials/cart-page.htm
@@ -14,6 +14,8 @@
   {% endfor %}
 {% endfor %}
 
+{% set hasAnyItems = items | length > 0 or upcomingItems | length > 0 %}
+
 <header class="cell">
   <h1>Cart</h1>
 </header>
@@ -38,7 +40,7 @@
             <a class="button hollow" href="/products">Continue Shopping</a>
           </div>
           <div class="cell large-shrink footer-right">
-            {% if items | length > 0 or upcomingItems | length > 0 %}
+            {% if hasAnyItems %}
               <a class="button" href="/checkout">Checkout</a>
             {% endif %}
           </div>

--- a/partials/checkout-totals.htm
+++ b/partials/checkout-totals.htm
@@ -90,6 +90,16 @@
     </div>
   {% endif %}
 
+  {% if totals.setupFee %}
+    <hr/>
+    <div class="cell small-8 title-cell">
+      Setup Fee:
+    </div>
+    <div class="cell small-4 value-cell currency-cell">
+        <span class="cell-value">{{ totals.setupFee | currency }}</span>
+    </div>
+  {% endif %}
+
   <hr/>
 
   <div class="cell small-8 title-cell total-cell">

--- a/partials/mini-cart.htm
+++ b/partials/mini-cart.htm
@@ -28,7 +28,7 @@ description: Displays a mini-cart with a subtotal and link to the full cart and 
 </div>
 <div class="grid-x grid-padding-x">
 
-  {% if cart.items | length > 0 %}
+  {% if cart.hasItems() %}
 
   <div class="cell subtotal-cell">
     <span class="cart-subtotal">Subtotal: {{ cart.getSubtotal() | currency }}</span>


### PR DESCRIPTION
## Changes

- Adds item + upcomingItems list checks to `cart-contents` partial.
- Renders checkout button on the cart page if there are `upcomingItems` set.
- Renders Setup Fee.

### Example - Setup Fee

<img width="398" alt="screen shot 2018-09-25 at 1 42 16 pm" src="https://user-images.githubusercontent.com/3967712/46041899-d7b8ba00-c0c8-11e8-9611-49dca90ef7a5.png">

## Test Checklist

- [ ] Regression test mixed cart item list renders on cart page.
- [ ] Regression test standard item list renders on cart page.
- [ ] Regression test mixed cart item list renders on checkout review.
- [ ] Regression test standard item list renders on checkout review.