### PR TITLE
Adds Address Page + Customer Profile Updates

### DIFF
--- a/pages/account-settings/page-account-settings.htm
+++ b/pages/account-settings/page-account-settings.htm
@@ -55,7 +55,7 @@ published: true
                         'class':'address-form'
                     })
                 }}
-                
+
                 <label>
                     Shpping Addresses
                     <select

--- a/pages/account-settings/page-account-settings.htm
+++ b/pages/account-settings/page-account-settings.htm
@@ -13,18 +13,83 @@ published: true
 
   {% if customer %}
     <section class="account-settings-addresses">
-      {{ partial('account-settings-addresses', {
-           'customer': customer,
-           'countries': countries
-         })
-      }}
-    </section>
 
+        <header>
+            <h3>Addresses</h3>
+        </header>
+
+        <section class="grid-x grid-padding-x">
+            <section class="cell medium-6">
+                {{
+                    open_form({
+                        'method': 'get',
+                        'class':'address-form'
+                    })
+                }}
+
+                <label>
+                    Billing Addresses
+                    <select
+                        class="address-selector"
+                        name="billingAddressId"
+                        data-current-state="{{ address.id }}"
+                        data-state-selector="#billing-state">
+                      {% for address in customer.billingAddresses %}
+                      <option value="{{ address.id }}" {{ option_state(billing.id, address.id) }}>
+                        {{ address.formatted_string }}
+                      </option>
+                      {% endfor %}
+                    </select>
+                    <span class="error"></span>
+                    <span class="form-error">Error.</span>
+                </label>
+                <button type="submit" class="button">Edit Billing Address</button>
+
+                {{ close_form() }}
+            </section>
+
+            <section class="cell medium-6">
+                {{
+                    open_form({
+                        'method': 'get',
+                        'class':'address-form'
+                    })
+                }}
+                
+                <label>
+                    Shpping Addresses
+                    <select
+                        class="address-selector"
+                        name="shippingAddressId"
+                        data-current-state="{{ address.id }}"
+                        data-state-selector="#billing-state">
+                      {% for address in customer.shippingAddresses %}
+                      <option value="{{ address.id }}" {{ option_state(shipping.id, address.id) }}>
+                        {{ address.formatted_string }}
+                      </option>
+                      {% endfor %}
+                    </select>
+                    <span class="error"></span>
+                    <span class="form-error">Error.</span>
+                </label>
+                <button type="submit" class="button">Edit Shipping Address</button>
+
+                {{ close_form() }}
+            </section>
+        </section>
+    </section>
     <section class="account-settings-password">
       {{ partial('account-settings-password') }}
     </section>
+    <script>
+        /**
+         * Sets address selector forms to point to the address page on form submission.
+         */
+        $('.address-form').submit(function (ev, handler){
+          $(this).attr('action', '/address/' + $(this).find('.address-selector').val());
+        });
+    </script>
   {% else %}
     You must be logged in to use this page.
   {% endif %}
-
 </section>

--- a/pages/account-settings/page-account-settings.htm
+++ b/pages/account-settings/page-account-settings.htm
@@ -13,82 +13,89 @@ published: true
 
   {% if customer %}
     <section class="account-settings-addresses">
+        {% if customer.hasBillingAddresses() and customer.hasShippingAddresses() %}
+            <header>
+                <h3>Addresses</h3>
+            </header>
 
-        <header>
-            <h3>Addresses</h3>
-        </header>
+            <section class="grid-x grid-padding-x">
+                <section class="cell medium-6">
+                    {{
+                        open_form({
+                            'method': 'get',
+                            'class':'address-form'
+                        })
+                    }}
 
-        <section class="grid-x grid-padding-x">
-            <section class="cell medium-6">
-                {{
-                    open_form({
-                        'method': 'get',
-                        'class':'address-form'
-                    })
-                }}
+                    <label>
+                        Billing Addresses
+                        <select
+                            class="address-selector"
+                            name="billingAddressId"
+                            data-current-state="{{ address.id }}"
+                            data-state-selector="#billing-state">
+                          {% for address in customer.billingAddresses %}
+                          <option value="{{ address.id }}" {{ option_state(billing.id, address.id) }}>
+                            {{ address.formatted_string }}
+                          </option>
+                          {% endfor %}
+                        </select>
+                        <span class="error"></span>
+                        <span class="form-error">Error.</span>
+                    </label>
+                    <button type="submit" class="button">Edit Billing Address</button>
 
-                <label>
-                    Billing Addresses
-                    <select
-                        class="address-selector"
-                        name="billingAddressId"
-                        data-current-state="{{ address.id }}"
-                        data-state-selector="#billing-state">
-                      {% for address in customer.billingAddresses %}
-                      <option value="{{ address.id }}" {{ option_state(billing.id, address.id) }}>
-                        {{ address.formatted_string }}
-                      </option>
-                      {% endfor %}
-                    </select>
-                    <span class="error"></span>
-                    <span class="form-error">Error.</span>
-                </label>
-                <button type="submit" class="button">Edit Billing Address</button>
+                    {{ close_form() }}
+                </section>
 
-                {{ close_form() }}
-            </section>
+                <section class="cell medium-6">
+                    {{
+                        open_form({
+                            'method': 'get',
+                            'class':'address-form'
+                        })
+                    }}
 
-            <section class="cell medium-6">
-                {{
-                    open_form({
-                        'method': 'get',
-                        'class':'address-form'
-                    })
-                }}
+                    <label>
+                        Shpping Addresses
+                        <select
+                            class="address-selector"
+                            name="shippingAddressId"
+                            data-current-state="{{ address.id }}"
+                            data-state-selector="#billing-state">
+                          {% for address in customer.shippingAddresses %}
+                          <option value="{{ address.id }}" {{ option_state(shipping.id, address.id) }}>
+                            {{ address.formatted_string }}
+                          </option>
+                          {% endfor %}
+                        </select>
+                        <span class="error"></span>
+                        <span class="form-error">Error.</span>
+                    </label>
+                    <button type="submit" class="button">Edit Shipping Address</button>
 
-                <label>
-                    Shpping Addresses
-                    <select
-                        class="address-selector"
-                        name="shippingAddressId"
-                        data-current-state="{{ address.id }}"
-                        data-state-selector="#billing-state">
-                      {% for address in customer.shippingAddresses %}
-                      <option value="{{ address.id }}" {{ option_state(shipping.id, address.id) }}>
-                        {{ address.formatted_string }}
-                      </option>
-                      {% endfor %}
-                    </select>
-                    <span class="error"></span>
-                    <span class="form-error">Error.</span>
-                </label>
-                <button type="submit" class="button">Edit Shipping Address</button>
-
-                {{ close_form() }}
+                    {{ close_form() }}
+                </section>
             </section>
         </section>
-    </section>
-    <section class="account-settings-password">
-      {{ partial('account-settings-password') }}
-    </section>
-    <script>
-        /**
-         * Sets address selector forms to point to the address page on form submission.
-         */
-        $('.address-form').submit(function (ev, handler){
-          $(this).attr('action', '/address/' + $(this).find('.address-selector').val());
-        });
-    </script>
+        <section class="account-settings-password">
+          {{ partial('account-settings-password') }}
+        </section>
+        <script>
+            /**
+             * Sets address selector forms to point to the address page on form submission.
+             */
+            $('.address-form').submit(function (ev, handler){
+              $(this).attr('action', '/address/' + $(this).find('.address-selector').val());
+            });
+        </script>
+    {% else %}
+        {{ partial('account-settings-addresses', {
+           'customer': customer,
+           'countries': countries
+         })
+      }}
+    {% endif %}
   {% else %}
     You must be logged in to use this page.
   {% endif %}

--- a/pages/account-settings/page-account-settings.htm
+++ b/pages/account-settings/page-account-settings.htm
@@ -1,10 +1,11 @@
 ---
-url: /account
-name: Account Settings
-description: Allows a logged in user to edit their account.
-action: shop:customerProfile
+action: 'shop:customerProfile'
+description: 'Allows a logged in user to edit their account.'
 template: default
+protocol: all
 published: true
+name: 'Account Settings'
+url: /account
 ---
 <section class="account grid-container">
   <header>
@@ -13,6 +14,19 @@ published: true
   {% if customer %}
     <section class="account-settings-addresses">
     {% if customer.hasBillingAddresses() and customer.hasShippingAddresses() %}
+        <header>
+            <h3>Customer Info</h3>
+        </header>
+
+        <section class="grid-x grid-padding-x">
+            <section class="cell">
+                {{
+                    partial('customer-details', {
+                        'customer' : customer
+                    })
+                }}
+            </section>
+        </section>
         {{
             partial('account-address-selectors', {
                 'customer' : customer

--- a/pages/account-settings/page-account-settings.htm
+++ b/pages/account-settings/page-account-settings.htm
@@ -10,92 +10,26 @@ published: true
   <header>
     <h1>Account</h1>
   </header>
-
   {% if customer %}
     <section class="account-settings-addresses">
-        {% if customer.hasBillingAddresses() and customer.hasShippingAddresses() %}
-            <header>
-                <h3>Addresses</h3>
-            </header>
-
-            <section class="grid-x grid-padding-x">
-                <section class="cell medium-6">
-                    {{
-                        open_form({
-                            'method': 'get',
-                            'class':'address-form'
-                        })
-                    }}
-
-                    <label>
-                        Billing Addresses
-                        <select
-                            class="address-selector"
-                            name="billingAddressId"
-                            data-current-state="{{ address.id }}"
-                            data-state-selector="#billing-state">
-                          {% for address in customer.billingAddresses %}
-                          <option value="{{ address.id }}" {{ option_state(billing.id, address.id) }}>
-                            {{ address.formatted_string }}
-                          </option>
-                          {% endfor %}
-                        </select>
-                        <span class="error"></span>
-                        <span class="form-error">Error.</span>
-                    </label>
-                    <button type="submit" class="button">Edit Billing Address</button>
-
-                    {{ close_form() }}
-                </section>
-
-                <section class="cell medium-6">
-                    {{
-                        open_form({
-                            'method': 'get',
-                            'class':'address-form'
-                        })
-                    }}
-
-                    <label>
-                        Shpping Addresses
-                        <select
-                            class="address-selector"
-                            name="shippingAddressId"
-                            data-current-state="{{ address.id }}"
-                            data-state-selector="#billing-state">
-                          {% for address in customer.shippingAddresses %}
-                          <option value="{{ address.id }}" {{ option_state(shipping.id, address.id) }}>
-                            {{ address.formatted_string }}
-                          </option>
-                          {% endfor %}
-                        </select>
-                        <span class="error"></span>
-                        <span class="form-error">Error.</span>
-                    </label>
-                    <button type="submit" class="button">Edit Shipping Address</button>
-
-                    {{ close_form() }}
-                </section>
-            </section>
-        </section>
-        <section class="account-settings-password">
-          {{ partial('account-settings-password') }}
-        </section>
-        <script>
-            /**
-             * Sets address selector forms to point to the address page on form submission.
-             */
-            $('.address-form').submit(function (ev, handler){
-              $(this).attr('action', '/address/' + $(this).find('.address-selector').val());
-            });
-        </script>
+    {% if customer.hasBillingAddresses() and customer.hasShippingAddresses() %}
+        {{
+            partial('account-address-selectors', {
+                'customer' : customer
+            })
+        }}
     {% else %}
-        {{ partial('account-settings-addresses', {
-           'customer': customer,
-           'countries': countries
-         })
-      }}
+        {{
+            partial('account-settings-addresses', {
+                'customer': customer,
+                'countries': countries
+            })
+        }}
     {% endif %}
+    </section>
+    <section class="account-settings-password">
+        {{ partial('account-settings-password') }}
+    </section>
   {% else %}
     You must be logged in to use this page.
   {% endif %}

--- a/pages/address/page-address.htm
+++ b/pages/address/page-address.htm
@@ -1,0 +1,29 @@
+---
+action: 'shop:customerAddress'
+template: default
+protocol: all
+published: true
+name: Address
+url: '/address/:addressId'
+---
+<section class="account grid-container">
+  <header>
+      <h1>Update Address</h1>
+  </header>
+{% if address %}
+    {% if address.is_billing %}
+        {% set parameterPrefix = 'billing' %}
+    {% else %}
+        {% set parameterPrefix = 'shipping' %}
+    {% endif %}
+    {{ partial('address-form', { addressParameterPrefix : parameterPrefix }) }}
+{% else %}
+  <div class="grid-x grid-padding-x">
+    <div class="cell">
+      <p>
+        The address you're asking for doesn't exist.
+      </p>
+    </div>
+  </div>
+{% endif %}
+</section>

--- a/partials/account-address-selectors.htm
+++ b/partials/account-address-selectors.htm
@@ -1,0 +1,63 @@
+<header>
+    <h3>Addresses</h3>
+</header>
+<section class="grid-x grid-padding-x">
+    <section class="cell medium-6">
+        {{
+            open_form({
+                'method': 'get',
+                'class':'address-form'
+            })
+        }}
+        <label>
+            Billing Addresses
+            <select
+                class="address-selector"
+                data-current-state="{{ address.id }}"
+                data-state-selector="#billing-state">
+              {% for address in customer.billingAddresses %}
+              <option value="{{ address.id }}" {{ option_state(billing.id, address.id) }}>
+                {{ address.formatted_string }}
+              </option>
+              {% endfor %}
+            </select>
+            <span class="error"></span>
+            <span class="form-error">Error.</span>
+        </label>
+        <button type="submit" class="button">Edit Billing Address</button>
+        {{ close_form() }}
+    </section>
+    <section class="cell medium-6">
+        {{
+            open_form({
+                'method': 'get',
+                'class':'address-form'
+            })
+        }}
+        <label>
+            Shpping Addresses
+            <select
+                class="address-selector"
+                data-current-state="{{ address.id }}"
+                data-state-selector="#billing-state">
+              {% for address in customer.shippingAddresses %}
+              <option value="{{ address.id }}" {{ option_state(shipping.id, address.id) }}>
+                {{ address.formatted_string }}
+              </option>
+              {% endfor %}
+            </select>
+            <span class="error"></span>
+            <span class="form-error">Error.</span>
+        </label>
+        <button type="submit" class="button">Edit Shipping Address</button>
+        {{ close_form() }}
+    </section>
+</section>
+<script>
+/**
+ * Sets address selector forms to point to the address page on form submission.
+ */
+$('.address-form').submit(function (ev, handler){
+  $(this).attr('action', '/address/' + $(this).find('.address-selector').val());
+});
+</script>

--- a/partials/account-settings-password.htm
+++ b/partials/account-settings-password.htm
@@ -9,35 +9,41 @@
    })
 }}
 {{ flash() }}
-<h3>Change password</h3>
 
-<label>
-  Old password*
-  <input type="password" name="oldPassword" required>
-  <span class="error"></span>
-  <span class="form-error">Old password is required</span>
-</label>
+<section class="grid-x grid-padding-x">
+    <header>
+        <h3>Change Password</h3>
+    </header>
+    <section class="cell">
+        <label>
+          Old password*
+          <input type="password" name="oldPassword" required>
+          <span class="error"></span>
+          <span class="form-error">Old password is required</span>
+        </label>
 
-<label>
-  New password*
-  <input type="password" name="password" id="password" required>
-  <span class="error"></span>
-  <span class="form-error">New password is required</span>
-</label>
+        <label>
+          New password*
+          <input type="password" name="password" id="password" required>
+          <span class="error"></span>
+          <span class="form-error">New password is required</span>
+        </label>
 
-<label>
-  Password confirmation*
-  <input
-      type="password"
-      name="passwordConfirm"
-      required
-      data-equalto="password">
-  <span class="error"></span>
-  <span class="form-error">
-      Password confirmation must match new password
-    </span>
-</label>
+        <label>
+          Password confirmation*
+          <input
+              type="password"
+              name="passwordConfirm"
+              required
+              data-equalto="password">
+          <span class="error"></span>
+          <span class="form-error">
+              Password confirmation must match new password
+            </span>
+        </label>
 
-<button type="submit" class="button">change password</button>
-<input type="hidden" name="redirect" value="/account"/>
+        <button type="submit" class="button">change password</button>
+        <input type="hidden" name="redirect" value="/account"/>
+    </section>
+</section>
 {{ close_form() }}

--- a/partials/address-form.htm
+++ b/partials/address-form.htm
@@ -59,7 +59,6 @@
     <span class="error"></span>
     <span class="form-error">Address is required.</span>
   </label>
-
   <label class="cell">
     Address (line 2)
     <input
@@ -116,6 +115,22 @@
     <span class="form-error">Error.</span>
   </label>
 </section>
+<label class="cell">
+    Is this your default address?
+    <div class="switch">
+      <input
+        id="default_address"
+        class="switch-input"
+        type="checkbox"
+        name="is_default"
+        {{ address.is_default ? 'checked' : '' }}>
+      <label class="switch-paddle" for="default_address">
+        <span class="show-for-sr">Is this your default address?</span>
+        <span class="switch-active" aria-hidden="true">Yes</span>
+        <span class="switch-inactive" aria-hidden="true">No</span>
+      </label>
+    </div>
+</label>
 <button type="submit" class="button">
   save address information
 </button>

--- a/partials/address-form.htm
+++ b/partials/address-form.htm
@@ -1,0 +1,122 @@
+{{ open_form({
+     'method': 'post',
+     'data-ajax-handler': 'shop:onUpdateCustomerProfile',
+     'data-abide': null,
+     'novalidate': null
+   })
+}}
+{{ flash() }}
+<input type="hidden" name="redirect" value="/address/{{ address.id }}">
+<section class="account-billing-address grid-x grid-padding-x">
+  <input type="hidden" name="{{ addressParameterPrefix }}[id]" value="{{ address.id }}">
+  <label class="cell medium-6">
+    First Name*
+    <input
+        type="text"
+        name="{{ addressParameterPrefix }}[first_name]"
+        value="{{ address.first_name }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">First name is required.</span>
+  </label>
+  <label class="cell medium-6">
+    Last Name*
+    <input
+        type="text"
+        name="{{ addressParameterPrefix }}[last_name]"
+        value="{{ address.last_name }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">Last name is required.</span>
+  </label>
+  <label class="cell medium-6">
+    Email*
+    <input
+        type="email"
+        name="{{ addressParameterPrefix }}[email]"
+        value="{{ customer.email }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">Email must be a valid email address.</span>
+  </label>
+  <label class="cell medium-6">
+    Phone Number
+    <input
+        type="tel"
+        name="{{ addressParameterPrefix }}[phone]"
+        value="{{ address.phone }}">
+    <span class="error"></span>
+    <span class="form-error">Error.</span>
+  </label>
+
+  <label class="cell">
+    Address*
+    <input
+        type="text"
+        name="{{ addressParameterPrefix }}[street_address]"
+        value="{{ address.street_address }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">Address is required.</span>
+  </label>
+
+  <label class="cell">
+    Address (line 2)
+    <input
+        type="text"
+        name="{{ addressParameterPrefix }}[street_address_line2]"
+        value="{{ address.street_address_line2 }}">
+    <span class="error"></span>
+    <span class="form-error">Error.</span>
+  </label>
+  <label class="cell medium-6">
+    City*
+    <input
+        type="text"
+        name="{{ addressParameterPrefix }}[city]"
+        value="{{ address.city }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">City is required.</span>
+  </label>
+  <label class="cell medium-6">
+    Postal Code*
+    <input
+        type="text"
+        name="{{ addressParameterPrefix }}[postal_code]"
+        value="{{ address.postal_code }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">Postal code is required.</span>
+  </label>
+  <label class="cell medium-6">
+    Country
+    <select
+        name="{{ addressParameterPrefix }}[shop_country_id]"
+        data-current-state="{{ address.country.id }}"
+        data-state-selector="#billing-state">
+      {% for country in countries %}
+      <option
+          value="{{ country.id }}"
+          {{ option_state(address.country.id, country.id) }}>
+        {{ country.name }}
+      </option>
+      {% endfor %}
+    </select>
+    <span class="error"></span>
+    <span class="form-error">Error.</span>
+  </label>
+  <label class="cell medium-6">
+    State
+    <select name="{{ addressParameterPrefix }}[shop_state_id]" id="billing-state">
+      {{ partial('shop-stateoptions',
+      {'states': states, 'selected': address.state.id}) }}
+    </select>
+    <span class="error"></span>
+    <span class="form-error">Error.</span>
+  </label>
+</section>
+<button type="submit" class="button">
+  save address information
+</button>
+{{ close_form() }}

--- a/partials/address-form.htm
+++ b/partials/address-form.htm
@@ -122,7 +122,7 @@
         id="default_address"
         class="switch-input"
         type="checkbox"
-        name="is_default"
+        name="{{ addressParameterPrefix }}[is_default]"
         {{ address.is_default ? 'checked' : '' }}>
       <label class="switch-paddle" for="default_address">
         <span class="show-for-sr">Is this your default address?</span>

--- a/partials/address-form.htm
+++ b/partials/address-form.htm
@@ -1,6 +1,6 @@
 {{ open_form({
      'method': 'post',
-     'data-ajax-handler': 'shop:onUpdateCustomerProfile',
+     'data-ajax-handler': 'shop:onUpdateCustomerAddress',
      'data-abide': null,
      'novalidate': null
    })
@@ -8,12 +8,12 @@
 {{ flash() }}
 <input type="hidden" name="redirect" value="/address/{{ address.id }}">
 <section class="account-billing-address grid-x grid-padding-x">
-  <input type="hidden" name="{{ addressParameterPrefix }}[id]" value="{{ address.id }}">
+  <input type="hidden" name="address[id]" value="{{ address.id }}">
   <label class="cell medium-6">
     First Name*
     <input
         type="text"
-        name="{{ addressParameterPrefix }}[first_name]"
+        name="address[first_name]"
         value="{{ address.first_name }}"
         required>
     <span class="error"></span>
@@ -23,27 +23,17 @@
     Last Name*
     <input
         type="text"
-        name="{{ addressParameterPrefix }}[last_name]"
+        name="address[last_name]"
         value="{{ address.last_name }}"
         required>
     <span class="error"></span>
     <span class="form-error">Last name is required.</span>
   </label>
-  <label class="cell medium-6">
-    Email*
-    <input
-        type="email"
-        name="{{ addressParameterPrefix }}[email]"
-        value="{{ customer.email }}"
-        required>
-    <span class="error"></span>
-    <span class="form-error">Email must be a valid email address.</span>
-  </label>
-  <label class="cell medium-6">
+  <label class="cell">
     Phone Number
     <input
         type="tel"
-        name="{{ addressParameterPrefix }}[phone]"
+        name="address[phone]"
         value="{{ address.phone }}">
     <span class="error"></span>
     <span class="form-error">Error.</span>
@@ -53,7 +43,7 @@
     Address*
     <input
         type="text"
-        name="{{ addressParameterPrefix }}[street_address]"
+        name="address[street_address]"
         value="{{ address.street_address }}"
         required>
     <span class="error"></span>
@@ -63,7 +53,7 @@
     Address (line 2)
     <input
         type="text"
-        name="{{ addressParameterPrefix }}[street_address_line2]"
+        name="address[street_address_line2]"
         value="{{ address.street_address_line2 }}">
     <span class="error"></span>
     <span class="form-error">Error.</span>
@@ -72,7 +62,7 @@
     City*
     <input
         type="text"
-        name="{{ addressParameterPrefix }}[city]"
+        name="address[city]"
         value="{{ address.city }}"
         required>
     <span class="error"></span>
@@ -82,7 +72,7 @@
     Postal Code*
     <input
         type="text"
-        name="{{ addressParameterPrefix }}[postal_code]"
+        name="address[postal_code]"
         value="{{ address.postal_code }}"
         required>
     <span class="error"></span>
@@ -91,7 +81,7 @@
   <label class="cell medium-6">
     Country
     <select
-        name="{{ addressParameterPrefix }}[shop_country_id]"
+        name="address[shop_country_id]"
         data-current-state="{{ address.country.id }}"
         data-state-selector="#billing-state">
       {% for country in countries %}
@@ -107,7 +97,7 @@
   </label>
   <label class="cell medium-6">
     State
-    <select name="{{ addressParameterPrefix }}[shop_state_id]" id="billing-state">
+    <select name="address[shop_state_id]" id="billing-state">
       {{ partial('shop-stateoptions',
       {'states': states, 'selected': address.state.id}) }}
     </select>
@@ -122,7 +112,7 @@
         id="default_address"
         class="switch-input"
         type="checkbox"
-        name="{{ addressParameterPrefix }}[is_default]"
+        name="is_default"
         {{ address.is_default ? 'checked' : '' }}>
       <label class="switch-paddle" for="default_address">
         <span class="show-for-sr">Is this your default address?</span>

--- a/partials/customer-details.htm
+++ b/partials/customer-details.htm
@@ -1,0 +1,46 @@
+{{ open_form({
+     'method': 'post',
+     'data-ajax-handler': 'shop:onUpdateCustomer',
+     'data-abide': null,
+     'novalidate': null
+   })
+}}
+{{ flash() }}
+<input type="hidden" name="redirect" value="/account">
+<section class="account-billing-address grid-x grid-padding-x">
+  <input type="hidden" name="address[id]" value="{{ address.id }}">
+  <label class="cell medium-6">
+    First Name*
+    <input
+        type="text"
+        name="first_name"
+        value="{{ customer.first_name }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">First name is required.</span>
+  </label>
+  <label class="cell medium-6">
+    Last Name*
+    <input
+        type="text"
+        name="last_name"
+        value="{{ customer.last_name }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">Last name is required.</span>
+  </label>
+  <label class="cell">
+    Email*
+    <input
+        type="email"
+        name="email"
+        value="{{ customer.email }}"
+        required>
+    <span class="error"></span>
+    <span class="form-error">Email must be a valid email address.</span>
+  </label>
+</section>
+<button type="submit" class="button">
+  Save Customer Info
+</button>
+{{ close_form() }}


### PR DESCRIPTION
## Changes

- Adds Address Page.
  - `<domain>/address/1`
- Adds account page selectors if a customer has more than one address
  - redirects to `<domain>/address/1`.
- Renders a top-level customer detail form to update first name, last name, email if a customer has multiple addresses.
- Nudges to address form.
  - Adds default switch to address forms.

### Example - Address Page

<img width="1221" alt="screen shot 2018-11-05 at 7 39 42 pm" src="https://user-images.githubusercontent.com/3967712/48041553-93422480-e132-11e8-8cfd-49489e5c1bcc.png">

### Example - Account Page With Multiple Addresses

<img width="1225" alt="screen shot 2018-11-05 at 7 40 36 pm" src="https://user-images.githubusercontent.com/3967712/48041588-afde5c80-e132-11e8-8edf-81f5c7abdb59.png">

### Example - Navigating to Address Page From Account Page

![updated-example](https://user-images.githubusercontent.com/3967712/48041696-385cfd00-e133-11e8-8b17-59cd50f8c593.gif)


### Updated Example - Profile Page with Multiple Addresses

## Test Checklist

- [ ] Verify individual address access for logged-in customers.
- [ ] Verify address updates.